### PR TITLE
Escape backlashes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,7 @@ export interface PostcssLitOptions {
 }
 
 const escapeBackticks = (str: string): string => str.replace(/`/g, '\\`');
+const escapeBackslash = (str: string): string => str.replace(/\\/g, '\\');
 
 export default function postcssLit(options: PostcssLitOptions = {
   include: '**/*.{css,sss,pcss,styl,stylus,sass,scss,less}',
@@ -34,7 +35,10 @@ export default function postcssLit(options: PostcssLitOptions = {
         if (node.type === 'VariableDeclaration') {
           const exportedVar = node.declarations.find(d => d.id.name === defaultExportName);
           if (exportedVar) {
-            exportedVar.init.edit.update(`cssTag\`${escapeBackticks(exportedVar.init.value)}\``);
+            let cssImport = escapeBackslash(exportedVar.init.value)
+            cssImport = escapeBackticks(cssImport)
+
+            exportedVar.init.edit.update(`cssTag\`${cssImport}\``);
           }
         }
       });

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ export interface PostcssLitOptions {
 }
 
 const escapeBackticks = (str: string): string => str.replace(/`/g, '\\`');
-const escapeBackslash = (str: string): string => str.replace(/\\/g, '\\');
+const escapeBackslash = (str: string): string => str.replace(/\\/g, '\\\\');
 
 export default function postcssLit(options: PostcssLitOptions = {
   include: '**/*.{css,sss,pcss,styl,stylus,sass,scss,less}',


### PR DESCRIPTION
This allows this plugin to import css styles with things like `content: '\e900';` (e.g. fontawesome icons).

As per https://github.com/Polymer/lit-element/issues/637.