### PR TITLE
Updates to newest version of 'lit'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ export = function postcssLit(options: PostcssLitOptions = {}): PluginOption {
   const defaultOptions = {
     include: '**/*.{css,sss,pcss,styl,stylus,sass,scss,less}',
     exclude: null,
-    importPackage: 'lit-element'
+    importPackage: 'lit'
   };
 
   const opts = {...defaultOptions, ...options};


### PR DESCRIPTION
This removes the deprecation warning for lit-element which shows up when using this plugin.